### PR TITLE
Fix DerObject::raw() to return correct object slice bounds

### DIFF
--- a/src/der.rs
+++ b/src/der.rs
@@ -141,6 +141,12 @@ impl<'a> DerObject<'a> {
             _ => Err(eio!("The object is truncated"))?,
         };
 
+        // Get the raw slice scoped to just this object (from header_start to value_end)
+        let raw = match raw.len() {
+            len if len >= value_end => &raw[header_start..value_end],
+            _ => Err(eio!("The object is truncated"))?,
+        };
+
         Ok(Self { raw, header, tag, value })
     }
     /// Reads a DER-TLV structure from `source` by parsing the length field and copying the


### PR DESCRIPTION
## Problem

The `raw()` method previously returned the entire input slice passed to `decode()` or `decode_at()`, including any trailing data or prefix bytes. This caused inconsistencies where `header().len() + value().len()` did not equal `raw().len()`.

## Solution

This fix ensures `raw()` returns only the bytes from `header_start` to `value_end`, representing just the DER-encoded object itself.

## Impact

- Fixes data leakage when `raw()` is used for hashing or signatures
- Ensures API contract correctness  
- Fixes sub-object extraction from sequences
- Maintains backward compatibility for correctly-written code

## Testing

- All existing tests pass
- Verified fix resolves the issue with trailing data
- Verified fix resolves sub-object extraction from sequences