### PR TITLE
Fix Integer::copy_numbytes to properly zero-fill buffer

### DIFF
--- a/src/typed/integer.rs
+++ b/src/typed/integer.rs
@@ -63,7 +63,11 @@ impl<'a> Integer<'a> {
             len => buf_slice.len() - len,
         };
 
-        // Copy the number and ensure that it can be represented
+        // Zero-fill the leading bytes (sign extension)
+        let fill_byte = if self.is_negative() { 0xFF } else { 0x00 };
+        buf_slice.iter_mut().take(to_skip).for_each(|b| *b = fill_byte);
+
+        // Copy the number bytes
         buf_slice.iter_mut().skip(to_skip).zip(slice.iter()).for_each(|(t, b)| *t = *b);
         Ok(buf)
     }


### PR DESCRIPTION
## Problem

The `copy_numbytes` method previously left leading bytes in the output buffer unmodified, causing incorrect numeric values when callers did not pre-zero the buffer.

For example, copying integer value `7` into a buffer `[0xFF, 0xFF, 0xFF, 0xFF]` would result in `[0xFF, 0xFF, 0xFF, 0x07]` instead of the expected `[0x00, 0x00, 0x00, 0x07]`.

## Solution

This fix adds proper sign extension by filling leading bytes with `0x00` for positive numbers and `0xFF` for negative numbers (two's complement representation).

## Impact

- Fixes API correctness for external callers
- Ensures correct sign extension for negative integers  
- Maintains backward compatibility (internal uses already zero-init buffers)

## Testing

- All existing tests pass
- Verified fix correctly zero-fills for positive integers
- Verified fix correctly sign-extends for negative integers