### PR TITLE
Reject non-canonical DER length encodings

### DIFF
--- a/src/der.rs
+++ b/src/der.rs
@@ -40,7 +40,14 @@ pub mod length {
                 // Validate the length
                 match usize::from_be_bytes(buf) {
                     len if len < 0b1000_0000 => Err(einval!("Encountered complex length < 128"))?,
-                    len => Ok(Some(len)),
+                    len => {
+                        // DER requires minimal encoding: the first byte of the length must be non-zero
+                        // (otherwise a shorter encoding would have been sufficient)
+                        if buf[skip] == 0 {
+                            Err(einval!("Non-canonical DER: length uses more bytes than necessary"))?
+                        }
+                        Ok(Some(len))
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

DER (Distinguished Encoding Rules) requires length fields to use the minimum number of octets per X.690 Section 10.1. Previously, the decoder accepted non-minimal encodings such as using two bytes to encode length 128 when one byte would suffice (e.g., `0x82 0x00 0x80` instead of `0x81 0x80`).

This violates DER strict encoding requirements and can lead to:
- Signature bypass attacks in PKI/certificate validation
- Parsing ambiguity in cryptographic contexts  
- Interoperability issues with strict DER parsers

## Solution

This fix validates that the first byte of multi-byte length encodings is non-zero, ensuring strict DER compliance.

## Impact

- Ensures strict DER specification compliance
- Prevents signature bypass attacks in cryptographic applications
- Eliminates parsing ambiguity
- Maintains backward compatibility with correctly-encoded inputs

## Testing

- All existing tests pass (they use canonical encodings)
- Verified canonical length encodings are still accepted
- Verified non-canonical encodings are now rejected